### PR TITLE
Respect name in stack trace.

### DIFF
--- a/lib/errs.js
+++ b/lib/errs.js
@@ -96,7 +96,7 @@ exports.create = function createErr(type, opts) {
   error = new (ErrorProto)(message);
 
   if (!error.name || error.name === 'Error') {
-    error.name = ErrorProto.name || 'Error';
+    error.name = (opts && opts.name) || ErrorProto.name || 'Error';
   }
 
   //

--- a/test/errs-test.js
+++ b/test/errs-test.js
@@ -45,7 +45,13 @@ vows.describe('errs').addBatch({
       "no parameters": macros.create.string('An error as a string'),
       "an object": {
         "that has no message": macros.create.object(opts[0]),
-        "that has a message": macros.create.object(opts[1])
+        "that has a message": macros.create.object(opts[1]),
+        "that has a name": {
+          topic : errs.create({name: 'OverflowError'}),
+          "should respect that name in the stack trace" : function (err) {
+            assert.match(err.stack, /^OverflowError/);
+          },
+        }
       },
       "an error": macros.create.err(new Error('An instance of an error')),
       "a function": macros.create.fn(function () {


### PR DESCRIPTION
This makes sure to set the name before doing `Error.call(error)` and capturing
the stack trace so the user-provided name is reflected in the stack trace
instead of the generic `Error: ...`.
