### PR TITLE
makes Error toJSON property writable

### DIFF
--- a/lib/errs.js
+++ b/lib/errs.js
@@ -20,6 +20,7 @@ exports.registered = {};
 if (!Error.prototype.toJSON) {
   Object.defineProperty(Error.prototype, 'toJSON', {
     enumerable: false,
+    writable: true,
     value: function () {
       return mixin({
         message: this.message,

--- a/test/errs-test.js
+++ b/test/errs-test.js
@@ -187,6 +187,16 @@ vows.describe('errs').addBatch({
         ['message', 'stack', 'arguments', 'type'].forEach(function (prop) {
           assert.isObject(Object.getOwnPropertyDescriptor(json, prop));
         })
+      },
+      "should be writable": function () {
+        var orig = Error.prototype.toJSON;
+        Error.prototype.toJSON = function() {
+          return 'foo';
+        };
+        var json = (new Error('Testing 12345')).toJSON();
+
+        assert.equal(json, 'foo');
+        Error.prototype.toJSON = orig;
       }
     }
   }


### PR DESCRIPTION
Makes Error.prototype.toJSON writable so that at least people can override it in their own libraries.

see: http://stackoverflow.com/questions/19966019/difference-between-method-and-property-on-an-object-in-node-js
